### PR TITLE
fix: better handle white spaces in paths mounted in docker container

### DIFF
--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -88,8 +88,9 @@ export interface BIDSDataset {
 	LastModificationDate?: Date
 }
 
+// FIXME: this should be updated with the new BIDS tools architecture
 const editScriptCmd = process.env.BIDS_SCRIPTS
-	? ['-v', `${process.env.BIDS_SCRIPTS}:/scripts`]
+	? ['-v', `"${process.env.BIDS_SCRIPTS}":/scripts`]
 	: undefined
 
 const isFulfilled = <T>(
@@ -1667,9 +1668,9 @@ export class ToolsService {
 			const cmd1 = [
 				'run',
 				'-v',
-				`${tmpDir}:/input`,
+				`"${tmpDir}":/input`,
 				'-v',
-				`${dsParentPath}:/output`
+				`"${dsParentPath}":/output`
 			]
 			const cmd2 = [
 				'bids-tools',
@@ -1737,7 +1738,13 @@ export class ToolsService {
 
 			const dbPath = await this.filePath(path, owner)
 
-			const cmd1 = ['run', '-v', `${tmpDir}:/input`, '-v', `${dbPath}:/output`]
+			const cmd1 = [
+				'run',
+				'-v',
+				`"${tmpDir}":/input`,
+				'-v',
+				`"${dbPath}":/output`
+			]
 			const cmd2 = [
 				'bids-tools',
 				this.dataUser,
@@ -1822,17 +1829,17 @@ export class ToolsService {
 			)
 
 			const volumes = nextCreateSubject.files.reduce(
-				(p, file) => [...p, '-v', `${file.path}:${file.path}`],
+				(p, file) => [...p, '-v', `"${file.path}":"${file.path}"`],
 				[]
 			)
 
 			const command = [
 				'run',
 				'-v',
-				`${tmpDir}:/import-data`,
+				`"${tmpDir}":/import-data`,
 				...volumes,
 				'-v',
-				`${dbPath}:/output`,
+				`"${dbPath}":/output`,
 				// '-v',  // 2 lines can be uncommented to debug interaction with BIDS manager
 				// '/home/stourbie/Softwares/bidsificator/bids_manager:/usr/local/lib/python3.8/dist-packages/bids_manager-0.3.2-py3.8.egg/bids_manager',
 				'bids-tools',
@@ -1871,7 +1878,7 @@ export class ToolsService {
 
 	/**
 	 * Run the BIDS validator on a given BIDS dataset
-	 * @param dbPath path to the BIDS dataset
+	 * @param dbPath Absolute path to the BIDS dataset
 	 * @returns True if the BIDS dataset is valid
 	 */
 	private async bidsValidate(dbPath: string) {
@@ -1879,7 +1886,7 @@ export class ToolsService {
 		const dockerParams = [
 			'run',
 			'-v',
-			`${dbPath}:/output`,
+			`"${dbPath}":/output`,
 			'bids/validator',
 			'/data'
 		]
@@ -1909,11 +1916,11 @@ export class ToolsService {
 			const cmd1 = [
 				'run',
 				'-v',
-				`${tmpDir}:/import-data`,
+				`"${tmpDir}":/import-data`,
 				'-v',
-				`${process.env.PRIVATE_FILESYSTEM}/${owner}/files:/input`,
+				`"${process.env.PRIVATE_FILESYSTEM}/${owner}/files":/input`,
 				'-v',
-				`${dbPath}:/output`
+				`"${dbPath}":/output`
 			]
 			const cmd2 = [
 				'bids-tools',
@@ -2156,7 +2163,13 @@ export class ToolsService {
 			// Set paths and command to be run
 			const dsPath = await this.filePath(path, owner)
 
-			const cmd1 = ['run', '-v', `${tmpDir}:/input`, '-v', `${dsPath}:/output`]
+			const cmd1 = [
+				'run',
+				'-v',
+				`"${tmpDir}":/input`,
+				'-v',
+				`"${dsPath}":/output`
+			]
 			const cmd2 = [
 				'bids-tools',
 				this.dataUser,
@@ -2231,7 +2244,7 @@ export class ToolsService {
 			)
 
 			const volumes = nextGetDatasets.datasets.reduce(
-				(p, dataset) => [...p, '-v', `${dataset.path}:${dataset.path}`],
+				(p, dataset) => [...p, '-v', `"${dataset.path}":"${dataset.path}"`],
 				[]
 			)
 
@@ -2246,7 +2259,7 @@ export class ToolsService {
 				}
 			})
 
-			const cmd1 = ['run', '-v', `${tmpDir}:/input`, ...volumes]
+			const cmd1 = ['run', '-v', `"${tmpDir}":/input`, ...volumes]
 			const cmd2 = [
 				'bids-tools',
 				this.dataUser,


### PR DESCRIPTION
This PR adds double quotes around paths mounted in a docker container (`-v "/path/to/x":"/path/to/y"`).