### PR TITLE
feature: use elasticsearch users with distinct roles 

### DIFF
--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -1705,7 +1705,7 @@ export class ToolsService {
 				// Index the dataset
 				await this.indexBIDSDataset(
 					owner,
-					`${dsParentPath}${createBidsDatasetDto.dataset_dirname}`,
+					`${createBidsDatasetDto.dataset_dirname}`,
 					datasetId
 				)
 


### PR DESCRIPTION
This PR integrates the use of two different elasticsearch clients that use two different users with different index privileges to perform read and write operations on the elasticsearch instance.