### PR TITLE
fix: handle user with no dataset found

### DIFF
--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -1262,6 +1262,18 @@ export class ToolsService {
 			const s = await this.search(cookie, PARTICIPANTS_FILE)
 			const searchDatasetsResults = s?.entries
 
+			// return empty lists if no dataset found
+			if (searchDatasetsResults.length === 0) {
+				this.logger.warn(
+					'SKIP: Refresh BIDS Datasets Index because no dataset found!'
+				)
+				return {
+					addedDatasets: [],
+					renamedDatasets: [],
+					deletedDatasets: []
+				}
+			}
+
 			// get the list of datasets already indexed in the root of the user private space
 			// let searchIndexedResults = await this.searchBidsDatasets(owner)
 


### PR DESCRIPTION
This fixes the following error raised by `refreshBIDSDatasetsIndex` and received for user with no existing dataset during hip web app loading:

```output
[Nest] 3448762  - 03/21/2023, 2:52:55 PM   ERROR [ToolsService] HttpException: parse_exception
        Root causes:
                parse_exception: request body or source parameter is required

/home/stourbie/Softwares/HIP/frontend/gateway/src/tools/tools.service.ts:1352
                        throw new HttpException(e.message, e.status || HttpStatus.BAD_REQUEST)
         ^
HttpException: parse_exception
        Root causes:
                parse_exception: request body or source parameter is required
    at ToolsService.refreshBIDSDatasetsIndex (/home/stourbie/Softwares/HIP/frontend/gateway/src/tools/tools.service.ts:1352:10)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```