### PR TITLE
fix: correct path which is already absolute and corrrect way to get first dataset from searchResults

### DIFF
--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -1530,9 +1530,9 @@ export class ToolsService {
 				ownerGroups = await this.nextcloudService.groupFoldersForUserId(owner)
 			}
 			// get abosolute path of the dataset
-			const dsPath = await this.filePath(path, owner, ownerGroups)
+			// const dsPath = await this.filePath(path, owner, ownerGroups)
 			// find the dataset index to be deleted
-			const datasetPathQuery = `Path:"${dsPath}"`
+			const datasetPathQuery = `Path:"${path}"`
 			const datasetPathQueryOpts: SearchBidsDatasetsQueryOptsDto = {
 				owner,
 				textQuery: datasetPathQuery,
@@ -1548,7 +1548,7 @@ export class ToolsService {
 				total: number | estypes.SearchTotalHits
 			} = await this.searchBidsDatasets(datasetPathQueryOpts)
 			if (searchResults.datasets.length > 0) {
-				const dataset = searchResults[0]
+				const dataset = searchResults.datasets[0]
 				// delete the document with id related to the dataset
 				const datasetID = {
 					index: dataset._index,


### PR DESCRIPTION
This fixes the error obtained while removing deleted BIDS dataset from the elasticsearch index.

It includes the following changes:
- Do not call `filePath()` as path is already absolute.
- Access the first dataset found by searchResults using `searchResults.datasets[0]` to take into account the change I made previously to `searchBidsDatasets()` to return a JSON object with datasets and total properties.