### PR TITLE
fix(tools.service): add Owner in the the Lucene query that searches for existing indexed datasets

### DIFF
--- a/src/tools/tools.service.ts
+++ b/src/tools/tools.service.ts
@@ -872,7 +872,7 @@ export class ToolsService {
 		// find IDs of datasets with name existing in the index in the case of
 		// (1) a dataset with changed path and (2) a dataset copy
 		let foundRenamedDatasetsQuery = foundDatasets.map(
-			(d: BIDSDataset) => `"${d.Name}"`
+			(d: BIDSDataset) => `(Name:"${d.Name}") AND (Owner:"${owner}")`
 		)
 		const searchRenamedResults = await this.multiSearchBidsDatasets(
 			foundRenamedDatasetsQuery


### PR DESCRIPTION
This should fix:
- the issue in indexing datasets that might not be ours,
- the issue in not being able to index two times a dataset that is owned and existing for two distinct users and have exactly the same directory and dataset names.