### PR TITLE
feat: check about groupfolders presence

### DIFF
--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -210,6 +210,13 @@ function to change the ownership of the user's folder in the collab workspace to
 			const groupfolderPath = `${this.configService.get(
 				'collab.mountPoint'
 			)}/__groupfolders`
+
+			// Ensure the collab workspace is properly mounted.
+			if (!jetpack.exists(groupfolderPath)) {
+				this.logger.debug(`mount point seems missing. ${groupfolterPath}`)
+				throw new Error(`mount point is missing for group folders`)
+			}
+
 			const projectPath = `${groupfolderPath}/${name}`
 
 			jetpack.dir(projectPath)

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -213,7 +213,7 @@ function to change the ownership of the user's folder in the collab workspace to
 
 			// Ensure the collab workspace is properly mounted.
 			if (!jetpack.exists(groupfolderPath)) {
-				this.logger.debug(`mount point seems missing. ${groupfolterPath}`)
+				this.logger.debug(`mount point seems missing. ${groupfolderPath}`)
 				throw new Error(`mount point is missing for group folders`)
 			}
 


### PR DESCRIPTION
As this is mounted from a remote location, upon a reboot, the folder will be missing and the gateway shouldn't blindly recreate it.

Signed-off-by: Yoan Blanc <yoan.blanc@chuv.ch>
